### PR TITLE
Allow Stringified Keys and Boolean type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_schematize (0.1.0)
+    json_schematize (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -85,7 +85,14 @@ required -- Default is true. When not set, each instance class can optionally de
 converter -- Proc return is set to the field value. No furter validation is done. Given (value) as a parameter
 array_of_types -- Detailed example above. Set this value to true when the dig param is to an array and you want all values in array to be parsed the given type
 ```
+### Custom Classes
 
+```ruby
+class CustomClasses < JsonSchematize::Generator
+  # JsonSchematize::Boolean can be used as a type when expecting a conversion of possible true or false values converted into a TrueClass or FalseClass
+  add_field name: :internals, type: JsonSchematize::Boolean
+end
+```
 
 ## Development
 

--- a/lib/json_schematize.rb
+++ b/lib/json_schematize.rb
@@ -2,6 +2,7 @@
 
 require "json_schematize/version"
 require "json_schematize/generator"
+require "json_schematize/boolean"
 
 module JsonSchematize
   class Error < StandardError; end
@@ -10,4 +11,7 @@ module JsonSchematize
   class InvalidFieldByValidator < InvalidField; end
   class InvalidFieldByType < InvalidField; end
   class InvalidFieldByArrayOfTypes < InvalidField; end
+
+  ## Customized class errors
+  class UndefinedBoolean < Error; end
 end

--- a/lib/json_schematize/boolean.rb
+++ b/lib/json_schematize/boolean.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class JsonSchematize::Boolean
+  FALSE_VALUES = ["false", "f", "0", false]
+  TRUE_VALUES = ["true", "t", "1", true]
+
+  def self.new(val)
+    return false if FALSE_VALUES.include?(val)
+    return true if TRUE_VALUES.include?(val)
+
+    raise JsonSchematize::UndefinedBoolean, "#{val} is not a valid #{self.class}"
+  end
+end

--- a/lib/json_schematize/generator.rb
+++ b/lib/json_schematize/generator.rb
@@ -67,9 +67,9 @@ class JsonSchematize::Generator
 
   attr_reader :__raw_params, :raise_on_error
 
-
-  def initialize(raise_on_error: true, **params)
-    @__params = params
+  # stringified_params allows for params with stringed keys
+  def initialize(stringified_params = {}, raise_on_error: true, **params)
+    @__params = stringified_params.empty? ? params : stringified_params
     @raise_on_error = raise_on_error
 
     validate_required!

--- a/lib/json_schematize/version.rb
+++ b/lib/json_schematize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JsonSchematize
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/json_schematize/boolean_spec.rb
+++ b/spec/lib/json_schematize/boolean_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe JsonSchematize::Boolean do
+  let(:instance) { described_class.new(input) }
+
+  describe ".initialize" do
+    shared_examples "basic" do
+    end
+
+    context 'with true' do
+      let(:expected) { true }
+      described_class::TRUE_VALUES.each do |val|
+        context "when #{val}" do
+          let(:input) { val }
+
+          it { expect(instance).to eq(expected) }
+        end
+      end
+    end
+
+    context 'when false' do
+      let(:expected) { false }
+      described_class::FALSE_VALUES.each do |val|
+        context "when #{val}" do
+          let(:input) { val }
+
+          it { expect(instance).to eq(expected) }
+        end
+      end
+    end
+
+    context 'when not valid value' do
+      let(:input) { nil }
+
+      it { expect { instance }.to raise_error(JsonSchematize::UndefinedBoolean) }
+    end
+  end
+end


### PR DESCRIPTION
## Changelog:
- String keys do not double splat out correctly -- allow for string keys to be passed as a parameter and for KWARGS to be passed
- Add Boolean type class -- Allows for downstream classes to include `JsonSchematize::Boolean` as a type for proper validation