### PR TITLE
Fix bug with Custom classes

### DIFF
--- a/lib/json_schematize.rb
+++ b/lib/json_schematize.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-require "json_schematize/version"
-require "json_schematize/generator"
+require "json_schematize/base"
 require "json_schematize/boolean"
+require "json_schematize/generator"
+require "json_schematize/version"
 
 module JsonSchematize
   class Error < StandardError; end

--- a/lib/json_schematize/base.rb
+++ b/lib/json_schematize/base.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class JsonSchematize::Base
+  def self.acceptable_types
+    raise NoMethodError, "Expected acceptable_values to be defined in parent class"
+  end
+end

--- a/lib/json_schematize/boolean.rb
+++ b/lib/json_schematize/boolean.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class JsonSchematize::Boolean
+require "json_schematize/base"
+
+class JsonSchematize::Boolean < JsonSchematize::Base
   FALSE_VALUES = ["false", "f", "0", false]
   TRUE_VALUES = ["true", "t", "1", true]
 
@@ -9,5 +11,9 @@ class JsonSchematize::Boolean
     return true if TRUE_VALUES.include?(val)
 
     raise JsonSchematize::UndefinedBoolean, "#{val} is not a valid #{self.class}"
+  end
+
+  def self.acceptable_types
+    [TrueClass, FalseClass]
   end
 end

--- a/lib/json_schematize/field.rb
+++ b/lib/json_schematize/field.rb
@@ -36,9 +36,9 @@ class JsonSchematize::Field
 
   def acceptable_value?(transformed_value:, raise_on_error:)
     if array_of_types
-      boolean = transformed_value.all? { |val| @acceptable_types.include?(val.class) }
+      boolean = transformed_value.all? { |val| validate_acceptable_types(val: val) }
     else
-      boolean = @acceptable_types.include?(transformed_value.class)
+      boolean = validate_acceptable_types(val: transformed_value)
     end
 
     if raise_on_error && (boolean==false)
@@ -76,6 +76,18 @@ class JsonSchematize::Field
   end
 
   private
+
+  def validate_acceptable_types(val:)
+    (all_allowed_types + @acceptable_types).include?(val.class)
+  end
+
+  def all_allowed_types
+    @all_allowed_types ||= begin
+      @acceptable_types.map do |t|
+        t.acceptable_types if t.ancestors.include?(JsonSchematize::Base)
+      end.compact.flatten
+    end
+  end
 
   def iterate_array_of_types(value:)
     return raw_converter_call(value: value) unless array_of_types

--- a/lib/json_schematize/version.rb
+++ b/lib/json_schematize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JsonSchematize
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
## Changelog:
- custom classes must now be a child of `JsonSchematize::Base`
- `acceptable_types` must be a class method for custom classes
- `acceptable_types` gets added automagically as the acceptable types when doing validation checking