### PR TITLE
Handle empty/nil values for non required fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ schema.id #=> 999999
 ```
 
 ### Field options:
-```bash
+```
 name -- Name of the field. Field name can be accessed from the instance
 type -- Class of the expected field type
 types -- To be used when you want the field to have multiple types. Useful for similar classes like DateTime, Date, Time (converter must be supplied when multiple types are given)
@@ -84,6 +84,7 @@ validator -- Proc value to validate the data found in the params. Proc given (tr
 required -- Default is true. When not set, each instance class can optionally decide if they want to raise when an this is set to false.
 converter -- Proc return is set to the field value. No furter validation is done. Given (value) as a parameter
 array_of_types -- Detailed example above. Set this value to true when the dig param is to an array and you want all values in array to be parsed the given type
+empty_value -- When required is false, this value is used to fill the field. By default it is JsonSchematize::EmptyValue, but can be changed to anything
 ```
 
 ### Schema defaults
@@ -96,7 +97,7 @@ class SchemaWithDefaults < JsonSchematize::Generator
 
   add_field name: :internals, type: InternalBody, array_of_types: true
   add_field name: :id, type: Integer
-  add_field name: :status, type: Symbol
+  add_field name: :status, type: Symbol, required: false, empty_value: "empty"
 end
 ```
 

--- a/lib/json_schematize/empty_value.rb
+++ b/lib/json_schematize/empty_value.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class JsonSchematize::EmptyValue
+  def initialize(*)
+  end
+end

--- a/lib/json_schematize/field_validators.rb
+++ b/lib/json_schematize/field_validators.rb
@@ -2,7 +2,7 @@
 
 module JsonSchematize::FieldValidators
 
-  def valiadtions!
+  def validations!
     validate_type!(t: @type)
     validate_types!
     validate_name!

--- a/lib/json_schematize/generator.rb
+++ b/lib/json_schematize/generator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json_schematize/empty_value"
 require "json_schematize/field"
 require "json_schematize/introspect"
 
@@ -9,7 +10,7 @@ class JsonSchematize::Generator
 
   include JsonSchematize::Introspect
 
-  def self.add_field(name:, type: nil, types: nil, dig_type: nil, dig: nil, validator: nil, required: nil, converter: nil, array_of_types: nil)
+  def self.add_field(name:, type: nil, types: nil, dig_type: nil, dig: nil, validator: nil, required: nil, converter: nil, array_of_types: nil, empty_value: nil)
     field_params = {
       converter: converter || schema_defaults[:converter],
       dig: dig || schema_defaults[:dig],
@@ -18,6 +19,7 @@ class JsonSchematize::Generator
       required: (required.nil? ? schema_defaults.fetch(:required, true) : required),
       type: type || schema_defaults[:type],
       types: types || schema_defaults.fetch(:types, []),
+      empty_value: empty_value || schema_defaults.fetch(:empty_value, JsonSchematize::EmptyValue),
       validator: validator || schema_defaults.fetch(:validator, EMPTY_VALIDATOR),
       array_of_types: (array_of_types.nil? ? schema_defaults.fetch(:array_of_types, false) : array_of_types),
     }
@@ -95,7 +97,6 @@ class JsonSchematize::Generator
       @values_assigned = true
     end
   end
-
 
   private
 

--- a/lib/json_schematize/version.rb
+++ b/lib/json_schematize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JsonSchematize
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/lib/json_schematize/field_spec.rb
+++ b/spec/lib/json_schematize/field_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe JsonSchematize::Field do
       validator: validator_proc,
       converter: converter,
       array_of_types: array_of_types,
+      empty_value: empty_value,
     }
   end
   let(:name) { Faker::Name.name.delete(" ").to_sym }
@@ -23,6 +24,7 @@ RSpec.describe JsonSchematize::Field do
   let(:required) { true }
   let(:converter) { nil }
   let(:array_of_types) { false }
+  let(:empty_value) { JsonSchematize::EmptyValue }
   let(:validator_proc) { ->(_val, _raw_val) { true } }
 
   describe "#setup!" do
@@ -134,7 +136,7 @@ RSpec.describe JsonSchematize::Field do
       it do
         subject
 
-        expect(instance.acceptable_types.map(&:name).sort).to eq(converter.keys.map(&:name).sort)
+        expect(instance.acceptable_types.map(&:name).sort).to eq((converter.keys + [empty_value]).map(&:name).sort)
       end
     end
 
@@ -353,6 +355,18 @@ RSpec.describe JsonSchematize::Field do
 
     before { instance.setup! }
     it { is_expected.to eq(value.to_i) }
+
+    context 'when value is missing' do
+      let(:value) { nil }
+      let(:empty_value) { "empty_value returned" }
+
+      it { is_expected.to eq(value.to_i) }
+
+      context 'when field is not required' do
+        let(:required) { false }
+        it { is_expected.to eq(empty_value) }
+      end
+    end
 
     context 'when array_of_types is true' do
       let(:array_of_types) { true }


### PR DESCRIPTION
## Changelog:
- add `empty_value` as a param -- allows schema to choose how to handle non required params that are missing
- `empty_value` can also be used as schema default for the entire schema