### PR TITLE
Add Caching Adapter for requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,16 @@ jobs:
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
       - run:
+          name: Waiting for Redis to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z localhost 6379 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for Redis to be available && exit 1
+      - run:
           name: Run and Report tests
           command: |
             ./cc-test-reporter before-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,14 +152,12 @@ jobs:
       - run:
           name: Waiting for Redis to be ready
           command: |
-            sleep 5
             for i in `seq 1 10`;
             do
               nc -z localhost 6379 && echo Success && exit 0
               echo -n .
               sleep 1
             done
-
             echo Failed waiting for Redis to be available && exit 1
       - run:
           name: Run and Report tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,12 +152,14 @@ jobs:
       - run:
           name: Waiting for Redis to be ready
           command: |
+            sleep 5
             for i in `seq 1 10`;
             do
               nc -z localhost 6379 && echo Success && exit 0
               echo -n .
               sleep 1
             done
+
             echo Failed waiting for Redis to be available && exit 1
       - run:
           name: Run and Report tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ orbs:
 common_envs: &common_envs
   environment:
     APP_BUNDLER_VERSION: "2.3.8"
+    REDIS_URL: "redis://127.0.0.1"
 
 executors:
   gem:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ orbs:
 common_envs: &common_envs
   environment:
     APP_BUNDLER_VERSION: "2.3.8"
+    REDIS_URL: "redis://localhost:6391"
 
 executors:
   gem:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ executors:
         type: string
     docker:
       - image: cimg/ruby:<< parameters.ruby-version >>
+      - image: circleci/redis:6.0
+
     <<: *common_envs
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ orbs:
 common_envs: &common_envs
   environment:
     APP_BUNDLER_VERSION: "2.3.8"
-    REDIS_URL: "redis://localhost:6391"
 
 executors:
   gem:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - YYYY-MM-DD
+## [0.6.0] - 2021-04-01
 
 ### Added
-- New feature 1
+- Caching Layer
 - New feature 2
 
 ### Changed
@@ -24,3 +24,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bug fix 1
 - Bug fix 2
+
+[//]: # (Added, Changed, Removed, Fixed are the possible headers for each changlog version)

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'redis'
 gem 'faker'
 gem 'pry'
 gem 'rspec', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     rake (12.3.3)
+    redis (4.6.0)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -54,6 +55,7 @@ DEPENDENCIES
   pry
   pry-byebug
   rake (~> 12.0)
+  redis
   rspec (~> 3.0)
   rspec_junit_formatter
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_schematize (0.5.2)
+    json_schematize (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -110,6 +110,83 @@ class CustomClasses < JsonSchematize::Generator
 end
 ```
 
+### Caching Adapter
+
+JsonSchematize is built to be schema for API results. But what happens when you dont expect the result to change? Introducing the caching layer. This layer lets you cache a `JsonSchematize` object that can be queried from later
+
+**Note: This requires redis**
+
+```ruby
+class CachedClass < JsonSchematize::Generator
+  include JsonSchematize::Cache
+  cache_options key: ->(instance_of_cached_class, cache_key_from_initialization) { "#{instance_of_cached_class.id}:#{cache_key_from_initialization}" }
+  cache_options ttl: 7.days.to_i
+
+  schema_default option: :dig_type, value: :string
+
+  add_field name: :id, type: Integer
+end
+
+params = { id: 1 }
+CachedClass.new(cache_key: User.first.id, **params)
+###
+params = { "id" => 1 }
+CachedClass.new(params, cache_key: User.first.id)
+```
+
+#### Instance methods for Cache
+```ruby
+# optional cache_key added on initialization: Can be used to customize the cache entry for the instance
+item = CachedClass.new(cache_key: User.first.id, **params)
+
+# Update the cached item -- Note: This will overwrite the previous cached item IFF the `__cache_key__` remains the same. This is not gaurenteed
+# Optional Param: with_delete, Default true -- Will attempt to delete the original object
+item.__update_cache_item__
+
+# Manually delete the cached entry
+item.__clear_entry__!
+
+# Cache key for the item
+item.__cache_key__
+```
+
+#### Class methods for Cache
+```ruby
+# Retrieve all cached items for the class. Returns an array of CachedClass objects. Only objects that have not expired via TTL
+# Optional: key_includes: "string_expected_in_cache", default is nil and return everthing
+CachedClass.cached_items
+
+# Retrieves all valid object keys from the cache
+CachedClass.cached_keys
+
+# Clears all cached items for the given class
+CachedClass.clear_cache!
+
+# manually clear objects that have expired
+CachedClass.clear_unscored_items!
+```
+### Cache options
+```ruby
+# [Required] false; [Expect] Proc; [Return] String to be used as instance key; [Default] key will be the hash of the object
+cache_options key: ->(instance_of_class, custom_key) { }
+
+# [Required] false; [Expect] String; [Default] ENV["CACHE_LAYER_REDIS_URL"] || ENV["REDIS_URL"]
+cache_options redis_url: _redis_url_value
+
+# [Required] false; [Expect] Redis Object or Proc that returns value of Redis Client; [Default] Redis.new(url: redis_url)
+cache_options redis_client: redis_client
+
+# [Required] false; [Expect] Object that plays with to_s and has no spaces; [Default] Full class name downcased
+cache_options cache_namespace: cache_namespace
+
+# [Required] false; [Expect] Integer in seconds; [Default] 1 day
+cache_options ttl: (60 * 60)
+
+# [Required] false; [Expect] Boolean; [Default] true
+# Update the cache when a value has been changed manually
+cache_options update_on_change: true
+```
+
 ## Development
 
 This gem can be developed against local machine or while using docker. Simpleified Docker commands can be found in the `Makefile` or execute `make help`

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ cache_options ttl: (60 * 60)
 # [Required] false; [Expect] Boolean; [Default] true
 # Update the cache when a value has been changed manually
 cache_options update_on_change: true
+
+# [Required] false; [Expect] Float; [Default] 0.8
+# Expected value to be between 0 and 1. The sample rate that the class will clear oldcache values on retreival
+cache_options stochastic_cache_bust: 0.8
 ```
 
 ## Development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,13 @@ services:
       - .:/gem
       - ..:/local
       - bundle-cache:/usr/local/bundle:delegated
-
+    environment:
+      REDIS_URL: redis://redis
+    links:
+      - redis
+  redis:
+    image: redis
+    expose:
+      - 6379
 volumes:
   bundle-cache:

--- a/lib/json_schematize/cache.rb
+++ b/lib/json_schematize/cache.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "json_schematize/cache/instance_methods"
+require "json_schematize/cache/class_methods"
+
+module JsonSchematize
+  module Cache
+    def self.included(base)
+      raise StandardError, "Yikes! JsonSchematize::Cache Needs Redis to work. Include it as a gem" unless defined?(Redis)
+
+      base.include(JsonSchematize::Cache::InstanceMethods)
+      base.extend(JsonSchematize::Cache::ClassMethods)
+    end
+  end
+end

--- a/lib/json_schematize/cache/class_methods.rb
+++ b/lib/json_schematize/cache/class_methods.rb
@@ -8,7 +8,7 @@ module JsonSchematize
       DEFAULTS = {
         redis_url: DEFAULT_URL,
         ttl: DEFAULT_ONE_DAY,
-        key: ->(val) { val.hash },
+        key: ->(val, _custom_key) { val.hash },
         update_on_change: true,
         redis_client: ->() { ::Redis.new(url: DEFAULT_URL) },
       }

--- a/lib/json_schematize/cache/class_methods.rb
+++ b/lib/json_schematize/cache/class_methods.rb
@@ -57,9 +57,8 @@ module JsonSchematize
         clear_unscored_items! if rand >0.8
 
         cached_keys.map do |key|
-          stringed = redis_client.get(key)
-          string_key_hash = JSON.parse(stringed)
-          new(string_key_hash, skip_cache_update: true)
+          serialized_string = redis_client.get(key)
+          Marshal.load(serialized_string)
         end
       end
 

--- a/lib/json_schematize/cache/class_methods.rb
+++ b/lib/json_schematize/cache/class_methods.rb
@@ -1,0 +1,78 @@
+module JsonSchematize
+  module Cache
+    module ClassMethods
+      DEFAULT_ONE_MIN = 60 * 60
+      DEFAULT_ONE_HOUR = DEFAULT_ONE_MIN * 60
+      DEFAULT_ONE_DAY = DEFAULT_ONE_HOUR * 24
+      DEFAULTS = {
+        redis_url: ENV["CACHE_LAYER_REDIS_URL"] || ENV["REDIS_URL"],
+        ttl: DEFAULT_ONE_DAY,
+        key: ->(val) { val.hash },
+        update_on_change: true,
+        update_on_assignment: true,
+        update_on_assignment: true,
+      }
+
+      def cache_options(key: nil, redis_url: nil, redis_client: nil, cache_namespace: nil, ttl: nil, update_on_change: nil, update_on_assignment: nil)
+        cache_configuration[:key] = key if key
+        cache_configuration[:ttl] = ttl if ttl
+        cache_configuration[:update_on_change] = update_on_change if update_on_change
+        cache_configuration[:update_on_assignment] = update_on_assignment if update_on_assignment
+        cache_namespace = cache_configuration[:cache_namespace] = cache_namespace if cache_namespace
+
+        redis_client = cache_configuration[:redis_client] = redis_client if redis_client
+        redis_url = cache_configuration[:redis_url] = redis_url if redis_url
+      end
+
+      def cache_namespace
+        @cache_namespace ||= "jss:#{self.name.downcase}"
+      end
+
+      def cache_namespace=(namespace)
+        @cache_namespace ||= namespace
+      end
+
+      def cache_configuration
+        @cache_configuration ||= DEFAULTS
+      end
+
+      def redis_client=(client)
+        @redis_client = client
+      end
+
+      def redis_url=(url)
+        redis_client = ::Redis.new(url: url)
+      end
+
+      def redis_client
+        @redis_client ||= begin
+          ::Redis.new(url: DEFAULTS[:redis_url])
+        end
+      end
+
+      def cached_keys
+        max_length = Time.now.to_i + cache_configuration[:ttl].to_i + 10
+        redis_client.zrangebyscore(cache_namespace, Time.now.to_i, "+inf")
+      end
+
+      def cached_items
+        clear_unscored_items! if rand >0.8
+
+        cached_keys.map do |key|
+          stringed = redis_client.get(key)
+          string_key_hash = JSON.parse(stringed)
+          new(string_key_hash, skip_cache_update: true)
+        end
+      end
+
+      def clear_cache!
+        redis_client.unlink(*cached_keys) if cached_keys.length > 0
+        redis_client.unlink(cache_namespace)
+      end
+
+      def clear_unscored_items!
+        redis_client.zremrangebyscore(cache_namespace, "-inf", Time.now.to_i)
+      end
+    end
+  end
+end

--- a/lib/json_schematize/cache/class_methods.rb
+++ b/lib/json_schematize/cache/class_methods.rb
@@ -53,10 +53,14 @@ module JsonSchematize
         redis_client.zrangebyscore(cache_namespace, Time.now.to_i, "+inf")
       end
 
-      def cached_items
+      def cached_items(key_includes: nil)
         clear_unscored_items! if rand >0.8
 
         cached_keys.map do |key|
+          if key_includes
+            next unless key.include?(key_includes)
+          end
+
           serialized_string = redis_client.get(key)
           Marshal.load(serialized_string)
         end

--- a/lib/json_schematize/cache/class_methods.rb
+++ b/lib/json_schematize/cache/class_methods.rb
@@ -11,11 +11,13 @@ module JsonSchematize
         key: ->(val, _custom_key) { val.hash },
         update_on_change: true,
         redis_client: ->() { ::Redis.new(url: DEFAULT_URL) },
+        stochastic_cache_bust: 0.8,
       }
 
-      def cache_options(key: nil, redis_url: nil, redis_client: nil, cache_namespace: nil, ttl: nil, update_on_change: nil)
+      def cache_options(key: nil, redis_url: nil, redis_client: nil, cache_namespace: nil, ttl: nil, update_on_change: nil, stochastic_cache_bust: nil)
         cache_configuration[:key] = key if key
         cache_configuration[:ttl] = ttl if ttl
+        cache_configuration[:stochastic_cache_bust] = stochastic_cache_bust if stochastic_cache_bust
         cache_configuration[:update_on_change] = update_on_change if update_on_change
         cache_namespace = cache_configuration[:cache_namespace] = cache_namespace if cache_namespace
 
@@ -54,7 +56,7 @@ module JsonSchematize
       end
 
       def cached_items(key_includes: nil)
-        clear_unscored_items! if rand >0.8
+        clear_unscored_items! if rand > cache_configuration[:stochastic_cache_bust]
 
         cached_keys.map do |key|
           if key_includes

--- a/lib/json_schematize/cache/class_methods.rb
+++ b/lib/json_schematize/cache/class_methods.rb
@@ -32,7 +32,7 @@ module JsonSchematize
       end
 
       def cache_configuration
-        @cache_configuration ||= DEFAULTS
+        @cache_configuration ||= DEFAULTS.clone
       end
 
       def redis_client=(client)

--- a/lib/json_schematize/cache/instance_methods.rb
+++ b/lib/json_schematize/cache/instance_methods.rb
@@ -15,7 +15,7 @@ module JsonSchematize
         ttl = self.class.cache_configuration[:ttl].to_i
         score = Time.now.to_i + ttl
         client.zadd(__cache_namespace__, score, __cache_key__)
-        client.set(__cache_key__, self.to_h.to_json, ex: ttl)
+        client.set(__cache_key__, Marshal.dump(self), ex: ttl)
       end
 
       def __clear_entry__!
@@ -24,7 +24,7 @@ module JsonSchematize
       end
 
       def __cache_key__
-        "#{__cache_namespace__}:#{self.class.cache_configuration[:key].call(self)}"
+        "#{__cache_namespace__}:#{self.class.cache_configuration[:key].call(self, @__incoming_cache_key__)}"
       end
 
       def __cache_namespace__

--- a/lib/json_schematize/cache/instance_methods.rb
+++ b/lib/json_schematize/cache/instance_methods.rb
@@ -1,0 +1,29 @@
+module JsonSchematize
+  module Cache
+    module InstanceMethods
+      def initialize(stringified_params = nil, skip_cache_update: false, raise_on_error: true, **params)
+        super(stringified_params, raise_on_error: raise_on_error, **params)
+
+        if @values_assigned
+          __update_cache_item__ unless skip_cache_update
+        end
+      end
+
+      def __update_cache_item__
+        client = self.class.redis_client
+        ttl = self.class.cache_configuration[:ttl].to_i
+        score = Time.now.to_i + ttl
+        client.zadd(__cache_namespace__, score, __cache_key__)
+        client.set(__cache_key__, self.to_h.to_json, ex: ttl)
+      end
+
+      def __cache_key__
+        "#{__cache_namespace__}:#{self.class.cache_configuration[:key].call(self)}"
+      end
+
+      def __cache_namespace__
+        self.class.cache_namespace
+      end
+    end
+  end
+end

--- a/lib/json_schematize/cache/instance_methods.rb
+++ b/lib/json_schematize/cache/instance_methods.rb
@@ -5,16 +5,22 @@ module JsonSchematize
         super(stringified_params, raise_on_error: raise_on_error, **params)
 
         if @values_assigned
-          __update_cache_item__ unless skip_cache_update
+          __update_cache_item__(with_delete: false) unless skip_cache_update
         end
       end
 
-      def __update_cache_item__
+      def __update_cache_item__(with_delete: true)
+        __clear_entry__! if with_delete # needs to get done first in the event the cache_key changes
         client = self.class.redis_client
         ttl = self.class.cache_configuration[:ttl].to_i
         score = Time.now.to_i + ttl
         client.zadd(__cache_namespace__, score, __cache_key__)
         client.set(__cache_key__, self.to_h.to_json, ex: ttl)
+      end
+
+      def __clear_entry__!
+        self.class.redis_client.zrem(__cache_namespace__, __cache_key__)
+        self.class.redis_client.unlink(__cache_key__)
       end
 
       def __cache_key__

--- a/lib/json_schematize/cache/instance_methods.rb
+++ b/lib/json_schematize/cache/instance_methods.rb
@@ -1,9 +1,10 @@
 module JsonSchematize
   module Cache
     module InstanceMethods
-      def initialize(stringified_params = nil, skip_cache_update: false, raise_on_error: true, **params)
+      def initialize(stringified_params = nil, cache_key: nil, skip_cache_update: false, raise_on_error: true, **params)
         super(stringified_params, raise_on_error: raise_on_error, **params)
 
+        @__incoming_cache_key__ = cache_key
         if @values_assigned
           __update_cache_item__(with_delete: false) unless skip_cache_update
         end

--- a/lib/json_schematize/generator.rb
+++ b/lib/json_schematize/generator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json_schematize/cache"
 require "json_schematize/field"
 require "json_schematize/introspect"
 

--- a/lib/json_schematize/generator.rb
+++ b/lib/json_schematize/generator.rb
@@ -59,6 +59,12 @@ class JsonSchematize::Generator
     @optional_fields ||= []
   end
 
+  # def self.update_block(&block)
+  #   @skip_individual_updates = true
+  #   yield(cloned)
+  #   @skip_individual_updates = false
+  # end
+
   def self.convenience_methods(field:)
     unless self.instance_methods.include?(:"#{field.name}=")
       define_method(:"#{field.name}=") do |value|

--- a/lib/json_schematize/generator.rb
+++ b/lib/json_schematize/generator.rb
@@ -71,6 +71,7 @@ class JsonSchematize::Generator
         return false unless validate_value(**validate_params)
 
         instance_variable_set(:"@#{field.name}", value)
+        __update_cache__!
         return true
       end
     end
@@ -99,6 +100,13 @@ class JsonSchematize::Generator
   end
 
   private
+
+  def __update_cache__!
+    return unless self.class.include?(JsonSchematize::Cache)
+    return unless self.class.cache_configuration[:update_on_change]
+
+    __update_cache_item__
+  end
 
   def assign_values!
     self.class.fields.each do |field|

--- a/lib/json_schematize/version.rb
+++ b/lib/json_schematize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JsonSchematize
-  VERSION = "0.5.2"
+  VERSION = "0.6.0"
 end

--- a/spec/lib/json_schematize/cache_spec.rb
+++ b/spec/lib/json_schematize/cache_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Testing the Cache Layer Modules" do
       include JsonSchematize::Cache
 
       schema_default option: :dig_type, value: :string
-      cache_options key: ->(val) { val.id }
+      cache_options key: ->(val, _custom_val) { val.id }
 
       add_field name: :id, type: String
     end
@@ -77,7 +77,7 @@ RSpec.describe "Testing the Cache Layer Modules" do
         include JsonSchematize::Cache
 
         schema_default option: :dig_type, value: :string
-        cache_options key: ->(val) { val.id }
+        cache_options key: ->(val, _custom_val) { val.id }
         cache_options ttl: 2
 
         add_field name: :id, type: String
@@ -119,7 +119,7 @@ RSpec.describe "Testing the Cache Layer Modules" do
       class CacheKeyDefault < JsonSchematize::Generator
         include JsonSchematize::Cache
 
-        cache_options key: ->(val) { val.id }
+        cache_options key: ->(val, _custom_val) { val.id }
 
         add_field name: :id, type: String
       end
@@ -129,7 +129,7 @@ RSpec.describe "Testing the Cache Layer Modules" do
     let(:id) { "cool_beans_yo" }
 
     it { expect(klass.cache_configuration[:key]).to be_a(Proc) }
-    it { expect(klass.cache_configuration[:key].call(instance)).to eq(id) }
+    it { expect(klass.cache_configuration[:key].call(instance, nil)).to eq(id) }
   end
 
   context 'with custom ttl' do

--- a/spec/lib/json_schematize/cache_spec.rb
+++ b/spec/lib/json_schematize/cache_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "Testing the Cache Layer Modules" do
       class CacheRedisClientDefault < JsonSchematize::Generator
         include JsonSchematize::Cache
 
-        cache_options redis_client: Redis.new(url: "#{ENV['REDIS_URL']}15")
+        cache_options redis_client: Redis.new(url: "#{ENV['REDIS_URL']}/15")
 
         add_field name: :id, type: String
       end

--- a/spec/lib/json_schematize/cache_spec.rb
+++ b/spec/lib/json_schematize/cache_spec.rb
@@ -215,6 +215,21 @@ RSpec.describe "Testing the Cache Layer Modules" do
     it { expect(klass.redis_client.inspect).to include("/15") }
   end
 
+  context 'with stochastic_cache_bust set' do
+    let(:klass) do
+      class CacheRedisClientDefault < JsonSchematize::Generator
+        include JsonSchematize::Cache
+
+        cache_options stochastic_cache_bust: 0.123
+
+        add_field name: :id, type: String
+      end
+      CacheRedisClientDefault
+    end
+
+    it { expect(klass.cache_configuration[:stochastic_cache_bust]).to eq(0.123) }
+  end
+
   context 'with redis_url set' do
     let(:klass) do
       class CacheRedisClientDefault < JsonSchematize::Generator

--- a/spec/lib/json_schematize/cache_spec.rb
+++ b/spec/lib/json_schematize/cache_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+RSpec.describe "Testing the Cache Layer Modules" do
+  let(:instance) { klass.new(**params) }
+  before { klass.clear_cache! }
+
+  let(:klass) do
+    class CacheDefault < JsonSchematize::Generator
+      include JsonSchematize::Cache
+
+      schema_default option: :dig_type, value: :string
+      cache_options key: ->(val) { val.id }
+
+      add_field name: :id, type: String
+    end
+    CacheDefault
+  end
+  let(:params) { { id: 'id' } }
+
+  describe ".cached_keys" do
+    subject { klass.cached_keys }
+
+    it { expect { instance }.to change { klass.cached_keys.length }.by(1) }
+
+    it do
+      instance
+      expect(subject).to include(instance.__cache_key__)
+    end
+  end
+
+  describe ".clear_cache!" do
+    before { instance }
+    subject { klass.clear_cache! }
+
+    it do
+      expect(klass.cached_keys.length).to eq(1)
+
+      expect { subject }.to change { klass.cached_keys.length }.to(0)
+    end
+  end
+
+  describe ".cached_items" do
+    before do
+      times.times.each { |k| klass.new({'id'=>k}) }
+    end
+    subject { klass.clear_cache! }
+    let(:times) { 10 }
+
+    it do
+      expect(klass.cached_items).to all(be_a(klass))
+    end
+
+    it 'does not update redis cache on retrieval' do
+      klass.cached_items
+
+      expect_any_instance_of(klass).to_not receive(:__update_cache_item__)
+    end
+  end
+
+  describe ".clear_unscored_items!" do
+    let(:klass) do
+      class CacheDefault < JsonSchematize::Generator
+        include JsonSchematize::Cache
+
+        schema_default option: :dig_type, value: :string
+        cache_options key: ->(val) { val.id }
+        cache_options ttl: 2
+
+        add_field name: :id, type: String
+      end
+      CacheDefault
+    end
+
+    let(:keys) do
+      arr = []
+      times.times.each { |k| arr << klass.new({'id'=>k}).__cache_key__ }
+      arr
+    end
+
+    subject { klass.clear_cache! }
+    let(:times) { 10 }
+
+    it 'cached_items returns no items' do
+      keys
+      expect(klass.redis_client.keys).to include(*keys)
+      sleep(2) # redis keeps it's own time. No way to simulate this
+      expect(klass.redis_client.keys).to_not include(*keys)
+    end
+
+    it 'clears unscored items from primary' do
+      keys
+      sleep(2)
+      expect(klass.clear_unscored_items!).to eq(times)
+    end
+
+    it 'does not update redis cache on retrieval' do
+      klass.cached_items
+
+      expect_any_instance_of(klass).to_not receive(:__update_cache_item__)
+    end
+  end
+
+  context 'with custom cache_key' do
+    let(:klass) do
+      class CacheKeyDefault < JsonSchematize::Generator
+        include JsonSchematize::Cache
+
+        cache_options key: ->(val) { val.id }
+
+        add_field name: :id, type: String
+      end
+      CacheKeyDefault
+    end
+    let(:params) { { id: id } }
+    let(:id) { "cool_beans_yo" }
+
+    it { expect(klass.cache_configuration[:key]).to be_a(Proc) }
+    it { expect(klass.cache_configuration[:key].call(instance)).to eq(id) }
+  end
+end

--- a/spec/lib/json_schematize/cache_spec.rb
+++ b/spec/lib/json_schematize/cache_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "Testing the Cache Layer Modules" do
       class CacheRedisClientDefault < JsonSchematize::Generator
         include JsonSchematize::Cache
 
-        cache_options redis_client: Redis.new(url: "redis://redis/15")
+        cache_options redis_client: Redis.new(url: "#{ENV['REDIS_URL']}15")
 
         add_field name: :id, type: String
       end
@@ -220,7 +220,7 @@ RSpec.describe "Testing the Cache Layer Modules" do
       class CacheRedisClientDefault < JsonSchematize::Generator
         include JsonSchematize::Cache
 
-        cache_options redis_url: "redis://redis/15"
+        cache_options redis_url: "#{ENV['REDIS_URL']}/15"
 
         add_field name: :id, type: String
       end
@@ -230,6 +230,6 @@ RSpec.describe "Testing the Cache Layer Modules" do
     let(:id) { "cool_beans_yo" }
 
     it { expect(klass.redis_client.inspect).to include("/15") }
-    it { expect(klass.cache_configuration[:redis_url]).to eq("redis://redis/15") }
+    it { expect(klass.cache_configuration[:redis_url]).to eq("#{ENV['REDIS_URL']}/15") }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 require 'json_schematize'
 require 'faker'
 require 'pry'
+require 'redis'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
## What

I had the need for a caching layer. This caching layer can be used to cache requests that do not change too often. The caching layer is backed by Redis for now. 

## How

Look at updated readme Section: https://github.com/matt-taylor/json_schematize/tree/main#caching-adapter

## Changelog:
- Add caching later if desired
- Cache layer requires redis