### PR TITLE
[Fix] Array of types when not required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@1.0
   node: circleci/node@2
-  cst: cst/framework@1
+  cst: cst/framework@dev:set_versions
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@1.0
   node: circleci/node@2
-  cst: cst/framework@dev:set_versions
+  cst: cst/framework@1
 
 workflows:
   version: 2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,59 +1,62 @@
 PATH
   remote: .
   specs:
-    json_schematize (0.7.0)
+    json_schematize (0.9.0)
+      class_composer (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     byebug (11.1.3)
+    class_composer (1.0.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    faker (2.20.0)
+    faker (3.1.1)
       i18n (>= 1.8.11, < 2)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.15.0)
-    pry (0.13.1)
+    minitest (5.18.0)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.10.1)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
+      pry (>= 0.13, < 0.15)
     rake (12.3.3)
-    rspec (3.11.0)
-      rspec-core (~> 3.11.0)
-      rspec-expectations (~> 3.11.0)
-      rspec-mocks (~> 3.11.0)
-    rspec-core (3.11.0)
-      rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
-    rspec_junit_formatter (0.5.1)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -68,4 +71,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.8
+   2.4.8

--- a/lib/json_schematize/field.rb
+++ b/lib/json_schematize/field.rb
@@ -39,7 +39,11 @@ class JsonSchematize::Field
 
   def acceptable_value?(transformed_value:, raise_on_error:)
     if array_of_types
-      boolean = transformed_value.all? { |val| validate_acceptable_types(val: val) }
+      if transformed_value.is_a?(empty_value) && required == false
+        boolean = true
+      else
+        boolean = transformed_value.all? { |val| validate_acceptable_types(val: val) }
+      end
     else
       boolean = validate_acceptable_types(val: transformed_value)
     end
@@ -53,7 +57,11 @@ class JsonSchematize::Field
 
   def acceptable_value_by_validator?(transformed_value:, raw_value:, raise_on_error:)
     if array_of_types
-      boolean = transformed_value.all? { |val| validator.call(transformed_value, raw_value) }
+      if transformed_value.is_a?(empty_value) && required == false
+        boolean = true
+      else
+        boolean = transformed_value.all? { |val| validator.call(transformed_value, raw_value) }
+      end
     else
       boolean = validator.call(transformed_value, raw_value)
     end
@@ -94,6 +102,7 @@ class JsonSchematize::Field
 
   def iterate_array_of_types(value:)
     return raw_converter_call(value: value) unless array_of_types
+    return empty_value.new if value.nil? && required == false
 
     unless value.is_a?(Array)
       raise JsonSchematize::InvalidFieldByArrayOfTypes, ":#{name} expected to be an array based on :array_of_types flag. Given #{value.class}"

--- a/lib/json_schematize/generator.rb
+++ b/lib/json_schematize/generator.rb
@@ -10,7 +10,9 @@ class JsonSchematize::Generator
 
   include JsonSchematize::Introspect
 
-  def self.add_field(name:, type: nil, types: nil, dig_type: nil, dig: nil, validator: nil, required: nil, converter: nil, array_of_types: nil, empty_value: nil)
+  def self.add_field(name:, type: nil, types: nil, dig_type: nil, dig: nil, validator: nil, required: nil, converter: nil, array_of_types: nil, empty_value: nil, hash_of_types: nil, hash_of_types_key: "name")
+    require "json_schematize/empty_value"
+
     field_params = {
       converter: converter || schema_defaults[:converter],
       dig: dig || schema_defaults[:dig],

--- a/lib/json_schematize/version.rb
+++ b/lib/json_schematize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JsonSchematize
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
## Problem:
When Array of types was passed an empty value when it was not required, it failed validation.

## Solution:
Explicitly allow empty value to be set to array when not present